### PR TITLE
Sync pipeline fixes from upstream vocabularyTemplate PR #3

### DIFF
--- a/.github/actions/github_action_main.py
+++ b/.github/actions/github_action_main.py
@@ -18,185 +18,133 @@ import logging
 import os
 import subprocess
 import sys
-import logging.config
-
-logging_config = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "standard": {
-            "format": "%(asctime)s %(name)s:%(levelname)s: %(message)s",
-            "dateformat": "%Y-%m-%dT%H:%M:%S",
-        },
-    },
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-            "level": "INFO",
-            "formatter": "standard",
-            "stream": "ext://sys.stderr",
-        },
-    },
-    "loggers": {
-        "": {
-            "handlers": [
-                "console",
-            ],
-            "level": "INFO",
-            "propogate": False,
-        },
-    },
-}
-
-LOG_LEVELS = {
-    "DEBUG": logging.DEBUG,
-    "INFO": logging.INFO,
-    "WARNING": logging.WARNING,
-    "WARN": logging.WARNING,
-    "ERROR": logging.ERROR,
-    "FATAL": logging.CRITICAL,
-    "CRITICAL": logging.CRITICAL,
-}
-
-def getLogger():
-    return logging.getLogger("action_main")
 
 
 def main():
-    verbosity = "DEBUG".upper()
-    logging_config["loggers"][""]["level"] = verbosity
-    logging.config.dictConfig(logging_config)
-    L = getLogger()
-
     command = os.environ["INPUT_ACTION"]
-    L.debug(f"github_action_main: INPUT_ACTION: {command}")
+    print("github_action_main: INPUT_ACTION: ", command)
     path = os.environ["INPUT_PATH"]
     path = os.path.join(path, "docs")
     input = os.environ["INPUT_INPUTTTL"]
-    L.debug(f"inputttl string: {input}")
+    print(f"inputttl string: {input}")
     inputttl = input.split('|')
     for filename in inputttl:
         print(f"files to load: {filename}")
 
     input = os.environ["INPUT_INPUTVOCABURI"]
-    L.debug(f"inputvocaburi string: {input}")
+    print(f"inputvocaburi string: {input}")
     inputvocaburi = input.split('|')
     for auri in inputvocaburi:
         print(f"vocab URIs: {auri}")
 
     if len(inputttl) != len(inputvocaburi):
-        L.error(f"inputttl ({len(inputttl)}) and inputvocaburi ({len(inputvocaburi)}) counts do not match. Exiting.")
+        print(f"inputttl ({len(inputttl)}) and inputvocaburi ({len(inputvocaburi)}) counts do not match. Exiting.")
         sys.exit(-1)
 
     cachepath = "cache/vocabularies.db"
-    sourcevocabdir = "vocabulary"
+    sourcevocabdir = os.environ.get("INPUT_VOCABDIR") or "vocabulary"
+    print(f"github_action_main: source vocab directory: {sourcevocabdir}")
 
-    L.debug(f"github_action_main: target path for output: {path}")
+    print("github_action_main: target path for output: ", path)
     if path is None:
-        L.debug("Did not receive a valid path argument so we cannot run.")
+        print("Did not receive a valid path argument so we cannot run.")
         sys.exit(-1)
     if not os.path.exists(path):
         os.makedirs(path)
         os.chmod(path, 777)
-        L.debug(f"Created {path} since it didn't exist.")
+        print(f"Created {path} since it didn't exist.")
 
     # Process each vocabulary independently with a fresh cache DB so data from
     # previously-loaded vocabularies cannot pollute queries for the current one.
     for index, inputf in enumerate(inputttl):
         voc_uri = inputvocaburi[index]
-        L.info(f"=== Processing {inputf} ({voc_uri}) ===")
+        print(f"\n=== Processing {inputf} ({voc_uri}) ===")
 
         _reset_cache_db(cachepath)
 
         ttl_path = os.path.join(sourcevocabdir, inputf + ".ttl")
         if load_cachedb(ttl_path, cachepath, voc_uri) != 0:
-            L.warning(f"load_cachedb had problem processing: {inputf}, {voc_uri}; skipping")
+            print(f"load_cachedb had problem processing: {inputf}, {voc_uri}; skipping")
             continue
-        L.debug(f"load_cachedb call successful for: {inputf}, {voc_uri}")
+        print(f"load_cachedb call successful for: {inputf}, {voc_uri}")
 
         if command == "uijson":
-            L.debug("Generating uijson for inclusion in webUI build")
-            _run_uijson_in_container(os.path.join(path, inputf + ".json"), voc_uri)
+            print("Generating uijson for inclusion in webUI build")
+            _run_uijson_in_container(os.path.join(path, inputf + ".json"), voc_uri, cachepath)
         elif command == "docs":
-            L.debug("Generating markdown and html docs")
+            print("Generating markdown and html docs")
             md_path = os.path.join(path, inputf + ".md")
-            result = _run_docs_in_container(md_path, voc_uri)
+            result = _run_docs_in_container(md_path, voc_uri, cachepath)
             if result == 0:
                 _quarto_render_html(md_path, path)
             else:
-                L.debug(f"problem with {inputf}, don't call quarto")
+                print(f"problem with {inputf}, don't call quarto")
         else:
-            L.debug(f"Unknown command {command}.  Exiting.")
+            print(f"Unknown command {command}.  Exiting.")
             sys.exit(-1)
 
 
 def _reset_cache_db(cachepath: str):
     """Delete any prior cache DB file so each vocab starts from a clean store.
 
-    navocab's internal purge path is unreliable, so we remove the file here
-    before re-creating it via vocab.py load.
+    navocab's internal purge path is unreliable (see known issues), so we
+    remove the file here before re-creating it via vocab.py load.
     """
-    L = getLogger()
     cachedir = os.path.dirname(cachepath)
     if cachedir and not os.path.exists(cachedir):
         os.makedirs(cachedir)
     if os.path.exists(cachepath):
         try:
             os.remove(cachepath)
-            L.debug(f"Removed stale cache DB: {cachepath}")
+            print(f"Removed stale cache DB: {cachepath}")
         except OSError as e:
-            L.warning(f"Could not remove {cachepath}: {e}")
+            print(f"Could not remove {cachepath}: {e}")
 
 
 def load_cachedb(inputf, cachepath, voc_uri):
-    L = getLogger()
-    L.debug(f"cachdb file to load: {inputf}")
+    print(f"cachdb file to load: {inputf}")
     load_args = ["--verbosity", "DEBUG", "-s", cachepath, "load", inputf, voc_uri]
     result = _run_python_in_container("/app/tools/vocab.py", load_args, f="")
     if result == 0:
-        L.debug(f"vocab.py.load call successful for {inputf}")
+        print(f"vocab.py.load call successful for {inputf}")
         return 0
-    L.debug(f"vocab.py.load had problem processing {inputf}")
+    print(f"vocab.py.load had problem processing {inputf}")
     return 1
 
 
 def _quarto_render_html(markdown_in: str, output_path: str):
-    L = getLogger()
     result = subprocess.run(["/opt/quarto/bin/quarto", "render", markdown_in, "-t", "html"])
     if result.returncode == 0:
-        L.debug(f"Quarto call successful for {markdown_in}")
+        print(f"Quarto call successful for {markdown_in}")
         return 0
-    L.debug(f"Quarto had problem processing {markdown_in}")
+    print(f"Quarto had problem processing {markdown_in}")
     return 1
 
 
 def _run_make_in_container(target: str):
-    L = getLogger()
-    L.debug(f"In githubActionMain: make in container, target: {target}")
+    print("In githubActionMain: make in container, target: ", target)
     subprocess.run(["/usr/bin/make", "-C", "/app", "-f", "/app/Makefile", target])
 
 
-def _run_uijson_in_container(output_path: str, vocab_location: str):
-    L = getLogger()
+def _run_uijson_in_container(output_path: str, vocab_location: str, cachepath: str):
     with open(output_path, "w") as f:
-        vocab_args = ["-s", "/app/cache/vocabularies.db", "uijson", vocab_location, "-e"]
+        vocab_args = ["-s", cachepath, "uijson", vocab_location, "-e"]
         testflag = _run_python_in_container("/app/tools/vocab.py", vocab_args, f)
         if testflag == 0:
-            L.debug(f"Run_uijson: Successfully wrote uijson file to {output_path}")
+            print(f"Run_uijson: Successfully wrote uijson file to {output_path}")
             return 0
-        L.debug(f"problem processing {vocab_location}")
+        print(f"problem processing {vocab_location}")
         return 1
 
 
-def _run_docs_in_container(output_path: str, vocab_location: str):
-    L = getLogger()
+def _run_docs_in_container(output_path: str, vocab_location: str, cachepath: str):
     with open(output_path, "w") as f:
-        docs_args = ["/app/cache/vocabularies.db", vocab_location]
+        docs_args = [cachepath, vocab_location]
         testflag = _run_python_in_container("/app/tools/vocab2mdCacheV2.py", docs_args, f)
         if testflag == 0:
-            L.debug(f"Docs in container: Successfully wrote doc file {vocab_location} to {output_path}")
+            print(f"Docs in container: Successfully wrote doc file {vocab_location} to {output_path}")
             return 0
-        L.debug(f"vocab2mdCacheV2. problem processing {vocab_location}")
+        print(f"vocab2mdCacheV2. problem processing {vocab_location}")
         return 1
 
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
   path: 
     description: 'Path to the output directory for script output'
     required: true
+  vocabdir:
+    description: 'Repository-relative directory containing the source ttl files for this workflow. Defaults to "vocabulary" for single-vocabulary layouts; set to a different directory name to point the action at a per-topic subfolder.'
+    required: false
+    default: 'vocabulary'
   inputttl:
     description: 'list of skos rdf/turtle files **without** the .ttl extension'
     required: true
@@ -37,3 +41,4 @@ runs:   # see https://docs.github.com/en/actions/creating-actions/metadata-synta
     - ${{ inputs.path }}
     - ${{ inputs.inputttl }}
     - ${{ inputs.inputvocaburi }}
+    - ${{ inputs.vocabdir }}

--- a/tools/vocab2mdCacheV2.py
+++ b/tools/vocab2mdCacheV2.py
@@ -35,8 +35,6 @@ import logging.config
 import navocab  # this is a local python package with routines for
                 # for interacting with skos rdf in an sqlAlchemy database
 
-
-
 logging_config = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -75,9 +73,6 @@ LOG_LEVELS = {
     "CRITICAL": logging.CRITICAL,
 }
 
-def getLogger():
-    return logging.getLogger("voc2md")
-
 
 
 NS = {
@@ -86,8 +81,7 @@ NS = {
     "owl": "http://www.w3.org/2002/07/owl#",
     "skos": "http://www.w3.org/2004/02/skos/core#",
     "obo": "http://purl.obolibrary.org/obo/",
-    "dcterm": "http://purl.org/dc/terms/",
-    "bioe":"https://w3id.org/isample/biology/biosampledfeature/"
+    "dcterm": "http://purl.org/dc/terms/"
 }
 
 PFX = """
@@ -95,11 +89,14 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX bioe: <https://w3id.org/isample/biology/biosampledfeature/> 
 """
 
 INDENT = "  "
+verbosity = "INFO"
+#control print errors; these will appear in the output markdown file.
 
+def getLogger():
+    return logging.getLogger("vocab2mdCacheV2")
 
 def skosT(term):
     return rdflib.URIRef(f"{NS['skos']}{term}")
@@ -135,6 +132,13 @@ def getVocabRoot(g, v):
     Accepts both concept->scheme (``skos:topConceptOf``) and
     scheme->concept (``skos:hasTopConcept``) assertions, since SKOS
     vocabularies in the wild use either (or both).
+
+    If neither assertion appears, falls back to every concept in the
+    scheme treated as a flat root. The fallback honors both direct
+    ``rdf:type skos:Concept`` and subclass typings (``rdf:type ?C`` where
+    ``?C rdfs:subClassOf skos:Concept``) — the latter is needed for
+    vocabularies like MMISW whose items are typed with a bespoke class
+    that declares ``rdfs:subClassOf skos:Concept``.
     """
     q = PFX + """SELECT DISTINCT ?s WHERE {
         { ?s skos:topConceptOf ?vocabulary . }
@@ -142,10 +146,21 @@ def getVocabRoot(g, v):
         { ?vocabulary skos:hasTopConcept ?s . }
     }"""
     qres = g.query(q, initBindings={'vocabulary': v})
-    res = []
-    for row in qres:
-        res.append(row[0])
-    return res
+    res = [row[0] for row in qres]
+    if res:
+        return res
+
+    q = PFX + """SELECT DISTINCT ?s WHERE {
+        ?s skos:inScheme ?vocabulary .
+        {
+            ?s rdf:type skos:Concept .
+        } UNION {
+            ?s rdf:type ?cls .
+            ?cls rdfs:subClassOf skos:Concept .
+        }
+    }"""
+    qres = g.query(q, initBindings={'vocabulary': v})
+    return [row[0] for row in qres]
 
 def getNarrower(g, v, r):
     """Return concepts that are skos:broader of r.
@@ -178,11 +193,9 @@ def getObjects(g, s, p):
     WHERE {
         ?subject ?predicate ?o .
     }""")
-
     L.debug(f"getObject prefixes: {PFX}\n")
-    L.debug(f"getObject expand subject: {s.toPython()}\n")
-    L.debug(f"getObject expand predicate: {p.toPython()}\n")
-    # g.expand_curie(s)
+    L.debug(f"getObject subject: {s}\n")
+    L.debug(f"getObject predicate: {p}\n")
     qres = g.query(q, initBindings={'subject': s, 'predicate': p})
     L.debug(f"length of qres: {len(qres)}\n", )
     L.debug(f"qres: {qres}\n")
@@ -249,7 +262,7 @@ def describeTerm(g, t, depth=0, level=1):
 
     broader = getObjects(g, t, skosT('broader'))
     if len(broader) > 0:
-        res.append("")
+#        res.append("")
         res.append(f"- Child of:")
         for b in broader:
             bt = b.split('/')[-1]
@@ -270,7 +283,7 @@ def describeTerm(g, t, depth=0, level=1):
         res += lines
     seealsos = getObjects(g, t, rdfsT('seeAlso'))
     if len(seealsos) > 0:
-#        res.append("")
+#       res.append("")
         res.append(f"- See Also:")
         for seealso in seealsos:
             res.append(f"  * [{seealso.n3(g.namespace_manager)}]({seealso})")
@@ -285,7 +298,7 @@ def describeTerm(g, t, depth=0, level=1):
         res.append(f"- **Alternate labels:**")
         for altlabel in altlabels:
             res.append(f"{altlabel}{delimiter}")
-#        res.append("")
+ #       res.append("")
 
     sources = []
     for source in getObjects(g, t, dctT('source')):
@@ -298,7 +311,7 @@ def describeTerm(g, t, depth=0, level=1):
         res.append(f"- **Source:**")
         for source in sources:
             res.append(f"{source}{delimiter}")
-#        res.append("")
+ #       res.append("")
 
     res.append(f"- Concept URI: {t}")
     res.append("")
@@ -425,7 +438,9 @@ def main(source, vocabulary):
     # res = []
     # res.append(conceptschemelist(vgraph))
 
-    verbosity = "DEBUG".upper()
+    # logging verbosity is set with global varable , at top
+    # when run github action, log statements are in the github action log.
+    # verbosity = "DEBUG".upper()
     logging_config["loggers"][""]["level"] = verbosity
     logging.config.dictConfig(logging_config)
     L = getLogger()
@@ -434,14 +449,8 @@ def main(source, vocabulary):
     store = navocab.VocabularyStore(storage_uri=source)
     res = []
 
-    L.debug(f"vocab2md source: {source}")
-    L.debug(f"vocab2md vocabulary: {vocabulary}")
-
-    test = store._g.namespace_manager.expand_curie(vocabulary)
-    L.debug(f"Test: {test}")
-
     vocabulary = store.expand_name(vocabulary)
-    L.debug(f"main: call describeVocabulary for: {vocabulary}")
+    L.debug(f"main: call desribeVocabulary for: {vocabulary}")
     theMarkdown = describeVocabulary(store._g, vocabulary)
     res.append(theMarkdown)
     # send the result to stdout via print.


### PR DESCRIPTION
Incremental sync of three items from isamplesorg/vocabularyTemplate#3 not already present here:

- **github_action_main.py**: thread `cachepath` through to `_run_docs_in_container` and `_run_uijson_in_container` instead of hardcoding `/app/cache/vocabularies.db`. Load and docs/uijson steps now share one path.
- **vocab2mdCacheV2.getVocabRoot**: new fallback for vocabularies that don't declare top concepts — lists every `skos:inScheme` member as a flat root, honoring both direct `rdf:type skos:Concept` and subclass typings. No behavior change for existing vocabularies.
- **action.yml**: new optional `vocabdir` input (default `vocabulary`). Existing workflows need no changes.

## Test plan
- [ ] Dispatch the vocabulary workflow on `main` after merge; output should be identical to the last successful run.